### PR TITLE
Cleaner coverage report

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,9 +58,11 @@
     "sinon": "^4.2.0"
   },
   "jest": {
+    "coveragePathIgnorePatterns": ["<rootDir>/test-setup.js", "<rootDir>/src/assets/fixtures/", "<rootDir>/node_modules/"],
     "moduleNameMapper": {
       "^.+\\.(css|scss)$": "identity-obj-proxy"
     },
+    "testPathIgnorePatterns": ["<rootDir>/test-setup.js", "<rootDir>/src/assets/fixtures/", "<rootDir>/node_modules/"],
     "transform": {
       ".*": "./node_modules/jest-css-modules"
     },


### PR DESCRIPTION
A prerequisite for issue #5 since it makes comparisons easier.

## Changed:
*  Configures Jest to skip coverage info for the following files (in addition to the default `/node_modules`):
 * `test-setup.js`;
 * `/src/assets/fixtures/*.*`

The new format for the coverage report produced by `$ yarn run test --coverage` is shown below (for comparison with [its original format](https://github.com/hfagerlund/elections-carousel-component/issues/5#issue-314367738)):
```
-------------------|----------|----------|----------|----------|----------------|
File               |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
-------------------|----------|----------|----------|----------|----------------|
All files          |    82.81 |    56.91 |    94.44 |    79.65 |                |
 App.jsx           |    74.29 |    51.22 |    82.61 |    69.57 |... 65,68,70,71 |
 Bar.jsx           |    88.89 |    62.16 |      100 |      100 |          1,5,7 |
 Controls.jsx      |    73.17 |    48.98 |    91.67 |    58.82 |... 23,28,55,61 |
 ErrorBoundary.jsx |    82.86 |    57.14 |    90.91 |    81.82 |          21,29 |
 RidingHeader.jsx  |    87.88 |    57.58 |      100 |      100 |          1,5,7 |
 Ridings.jsx       |    88.57 |    59.46 |      100 |      100 |  1,11,13,15,17 |
 TextSummary.jsx   |    88.89 |    62.16 |      100 |      100 |          1,5,7 |
 TotalVotes.jsx    |    88.24 |       60 |      100 |      100 |          1,5,7 |
-------------------|----------|----------|----------|----------|----------------|
```

